### PR TITLE
[Routing] [HttpKernel] [FrameworkBundle] Static Site Generation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Deprecate `Symfony\Bundle\FrameworkBundle\Console\Application::add()` in favor of `Symfony\Bundle\FrameworkBundle\Console\Application::addCommand()`
  * Add `assertEmailAddressNotContains()` to the `MailerAssertionsTrait`
  * Add `framework.type_info.aliases` option
+ * Add `static-site-generation:generate` command
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Command/StaticSiteGenerationGenerateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/StaticSiteGenerationGenerateCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\HttpKernel\Exception\RuntimeException;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\StaticPageDumperInterface;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\StaticPagesGenerator;
+use Symfony\Component\Routing\StaticSiteGeneration\StaticPageUrisProviderInterface;
+
+/**
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+#[AsCommand(name: 'static-site-generation:generate', description: 'Generates static pages')]
+final class StaticSiteGenerationGenerateCommand extends Command
+{
+    public function __construct(
+        private readonly StaticPagesGenerator $staticPagesGenerator,
+        private readonly StaticPageDumperInterface $staticPageDumper,
+        private readonly StaticPageUrisProviderInterface $staticPageUrisProvider,
+    ) {
+        parent::__construct();
+    }
+
+    public function __invoke(
+        SymfonyStyle $io,
+        #[Option(description: 'A pattern to filter the pages to generate')] ?string $filterPattern = null,
+        #[Option(description: 'Do not dump pages')] bool $dryRun = false,
+    ): int {
+        $successful = true;
+
+        foreach ($this->staticPageUrisProvider->provide() as $uri) {
+            if (null !== $filterPattern && !preg_match($filterPattern, $uri)) {
+                continue;
+            }
+
+            try {
+                ['content' => $content, 'format' => $format] = $this->staticPagesGenerator->generate($uri);
+
+                if (false === $dryRun) {
+                    $this->staticPageDumper->dump($uri, $content, $format);
+                }
+
+                $io->info(\sprintf('Generated static page for URI "%s"', $uri));
+            } catch (RuntimeException $exception) {
+                $io->error(\sprintf('Generating page for URI "%s" failed : %s', $uri, $exception->getMessage()));
+                $successful = false;
+            }
+        }
+
+        return $successful ? Command::SUCCESS : Command::FAILURE;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -83,6 +83,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'routing.expression_language_provider',
         'routing.loader',
         'routing.route_loader',
+        'routing.static_site.params_provider',
         'scheduler.schedule_provider',
         'scheduler.task',
         'security.access_token_handler.oidc.encryption_algorithm',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -29,6 +29,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
 use Symfony\Bridge\Monolog\Processor\DebugProcessor;
 use Symfony\Bridge\Twig\Extension\CsrfExtension;
+use Symfony\Bundle\FrameworkBundle\Command\StaticSiteGenerationGenerateCommand;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Bundle\FullStack;
@@ -173,6 +174,7 @@ use Symfony\Component\RemoteEvent\Attribute\AsRemoteEventConsumer;
 use Symfony\Component\RemoteEvent\RemoteEvent;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Loader\AttributeServicesLoader;
+use Symfony\Component\Routing\StaticSiteGeneration\ParamsProviderInterface;
 use Symfony\Component\Scheduler\Attribute\AsCronTask;
 use Symfony\Component\Scheduler\Attribute\AsPeriodicTask;
 use Symfony\Component\Scheduler\Attribute\AsSchedule;
@@ -435,6 +437,8 @@ class FrameworkExtension extends Extension
         $this->registerRouterConfiguration($config['router'], $container, $loader, $config['enabled_locales']);
         $this->registerPropertyAccessConfiguration($config['property_access'], $container, $loader);
         $this->registerSecretsConfiguration($config['secrets'], $container, $loader, $config['secret'] ?? null);
+
+        $loader->load('http_kernel.php');
 
         $exceptionListener = $container->getDefinition('exception_listener');
 
@@ -1341,6 +1345,19 @@ class FrameworkExtension extends Extension
         if (null !== $config['default_uri']) {
             $container->getDefinition('router.request_context')
                 ->replaceArgument(0, $config['default_uri']);
+        }
+
+        $container->registerForAutoconfiguration(ParamsProviderInterface::class)
+            ->addTag('routing.static_site.params_provider');
+
+        if ($this->hasConsole()) {
+            $container->register('console.command.static_site_generation_generate', StaticSiteGenerationGenerateCommand::class)
+                ->setArguments([
+                    new Reference('http_kernel.static_site.pages_generator'),
+                    new Reference('http_kernel.static_site.page_dumper'),
+                    new Reference('routing.static_site.pages_uri_provider'),
+                ])
+                ->addTag('console.command');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_kernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_kernel.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\HttpKernel\StaticSiteGeneration\FilesystemStaticPageDumper;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\StaticPageDumperInterface;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\StaticPagesGenerator;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('http_kernel.static_site.pages_generator', StaticPagesGenerator::class)
+            ->args([
+                service('http_kernel'),
+                service('routing.static_site.pages_uri_provider'),
+            ])
+
+        ->set('http_kernel.static_site.page_dumper.filesystem', FilesystemStaticPageDumper::class)
+            ->args([
+                param('kernel.project_dir'),
+            ])
+        ->alias('http_kernel.static_site.page_dumper', 'http_kernel.static_site.page_dumper.filesystem')
+        ->alias(StaticPageDumperInterface::class, 'http_kernel.static_site.page_dumper')
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -40,6 +40,8 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\StaticSiteGeneration\StaticPageUrisProvider;
+use Symfony\Component\Routing\StaticSiteGeneration\StaticPageUrisProviderInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->parameters()
@@ -215,5 +217,12 @@ return static function (ContainerConfigurator $container) {
                 service('twig')->ignoreOnInvalid(),
             ])
             ->public()
+
+        ->set('routing.static_site.pages_uri_provider', StaticPageUrisProvider::class)
+            ->args([
+                service('router'),
+                tagged_locator('routing.static_site.params_provider'),
+            ])
+        ->alias(StaticPageUrisProviderInterface::class, 'routing.static_site.pages_uri_provider')
     ;
 };

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Deprecate implementing `__sleep/wakeup()` on kernels; use `__(un)serialize()` instead
  * Deprecate implementing `__sleep/wakeup()` on data collectors; use `__(un)serialize()` instead
  * Make `Profile` final and `Profiler::__sleep()` internal
+ * Add `StaticPageGenerator` to generate static page content
+ * Add `StaticPageDumperInterface` to dump a static page content into a storage
 
 7.3
 ---

--- a/src/Symfony/Component/HttpKernel/Exception/RuntimeException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/RuntimeException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+class RuntimeException extends \RuntimeException
+{
+}

--- a/src/Symfony/Component/HttpKernel/StaticSiteGeneration/FilesystemStaticPageDumper.php
+++ b/src/Symfony/Component/HttpKernel/StaticSiteGeneration/FilesystemStaticPageDumper.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\StaticSiteGeneration;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+final class FilesystemStaticPageDumper implements StaticPageDumperInterface
+{
+    private ?Filesystem $filesystem = null;
+
+    public function __construct(
+        private string $projectDir,
+    ) {
+    }
+
+    public function dump(string $uri, string $content, ?string $format = null): void
+    {
+        $fileName = '/' === $uri ? 'index.html' : $uri;
+
+        if ($format && !str_ends_with($uri, '.'.$format)) {
+            $fileName = \sprintf('%s.%s', $uri, $format);
+        }
+
+        $staticPagesDirectory = \sprintf('%s/%s/static-pages', $this->projectDir, $this->getPublicDirectory());
+
+        $this->filesystem ??= new Filesystem();
+        $this->filesystem->dumpFile(\sprintf('%s/%s', $staticPagesDirectory, $fileName), $content);
+    }
+
+    private function getPublicDirectory(): string
+    {
+        $defaultPublicDir = 'public';
+        $composerFilePath = \sprintf('%s/composer.json', $this->projectDir);
+
+        if (!file_exists($composerFilePath)) {
+            return $defaultPublicDir;
+        }
+
+        $this->filesystem ??= new Filesystem();
+        $composerConfig = json_decode($this->filesystem->readFile($composerFilePath), true, flags: \JSON_THROW_ON_ERROR);
+
+        return $composerConfig['extra']['public-dir'] ?? $defaultPublicDir;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/StaticSiteGeneration/StaticPageDumperInterface.php
+++ b/src/Symfony/Component/HttpKernel/StaticSiteGeneration/StaticPageDumperInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\StaticSiteGeneration;
+
+/**
+ * Dump a static page content into a storage.
+ *
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+interface StaticPageDumperInterface
+{
+    public function dump(string $uri, string $content, ?string $format): void;
+}

--- a/src/Symfony/Component/HttpKernel/StaticSiteGeneration/StaticPagesGenerator.php
+++ b/src/Symfony/Component/HttpKernel/StaticSiteGeneration/StaticPagesGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\StaticSiteGeneration;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\RuntimeException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
+
+/**
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+final readonly class StaticPagesGenerator
+{
+    public function __construct(
+        private HttpKernelInterface $kernel,
+    ) {
+    }
+
+    /**
+     * Generate page content for URI.
+     *
+     * @return array{content: string, format: ?string}
+     *
+     * @throws RuntimeException
+     */
+    public function generate(string $uri): array
+    {
+        $request = Request::create($uri);
+        try {
+            $response = $this->kernel->handle($request, HttpKernelInterface::MAIN_REQUEST);
+
+            if ($this->kernel instanceof TerminableInterface) {
+                $this->kernel->terminate($request, $response);
+            }
+        } catch (\Exception $e) {
+            throw new RuntimeException(\sprintf('Cannot generate page for URI "%s".', $uri), $e->getCode(), $e);
+        }
+
+        if (Response::HTTP_OK !== $response->getStatusCode()) {
+            throw new RuntimeException(\sprintf('Expected URI "%s" to return status code 200, got %d.', $uri, $response->getStatusCode()));
+        }
+
+        return [
+            'content' => $response->getContent(),
+            'format' => $request->getFormat($response->headers->get('Content-Type')),
+        ];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/StaticSiteGeneration/FilesystemStaticPageDumperTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/StaticSiteGeneration/FilesystemStaticPageDumperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\StaticSiteGeneration;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\FilesystemStaticPageDumper;
+
+class FilesystemStaticPageDumperTest extends TestCase
+{
+    private string $staticPagesDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->staticPagesDir = \sprintf('%s/symfony_http_kernel_test/static_pages/', sys_get_temp_dir());
+        $this->filesystem = new Filesystem();
+
+        if (is_dir($this->staticPagesDir)) {
+            $this->filesystem->remove($this->staticPagesDir);
+        }
+    }
+
+    public function testDumpContent()
+    {
+        $dumper = new FilesystemStaticPageDumper($this->staticPagesDir);
+        $dumper->dump('page-foo', 'dummy-content');
+
+        $expectedPath = \sprintf('%s/public/static-pages/%s', $this->staticPagesDir, 'page-foo');
+
+        $this->assertTrue($this->filesystem->exists($expectedPath));
+        $this->assertSame('dummy-content', $this->filesystem->readFile($expectedPath));
+    }
+
+    public function testAppendFormat()
+    {
+        $dumper = new FilesystemStaticPageDumper($this->staticPagesDir);
+        $dumper->dump('page-foo', 'dummy-content', 'html');
+
+        $expectedPath = \sprintf('%s/public/static-pages/%s.html', $this->staticPagesDir, 'page-foo');
+
+        $this->assertTrue($this->filesystem->exists($expectedPath));
+        $this->assertSame('dummy-content', $this->filesystem->readFile($expectedPath));
+    }
+
+    public function testCustomPublicDir()
+    {
+        $dumper = new FilesystemStaticPageDumper($this->staticPagesDir);
+        $this->filesystem->dumpFile(\sprintf('%s/composer.json', $this->staticPagesDir), json_encode([
+            'extra' => [
+                'public-dir' => 'custom-public',
+            ],
+        ]));
+
+        $dumper->dump('page-foo', 'dummy-content');
+        $expectedPath = \sprintf('%s/custom-public/static-pages/%s', $this->staticPagesDir, 'page-foo');
+
+        $this->assertTrue($this->filesystem->exists($expectedPath));
+        $this->assertSame('dummy-content', $this->filesystem->readFile($expectedPath));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/StaticSiteGeneration/StaticPagesGeneratorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/StaticSiteGeneration/StaticPagesGeneratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\StaticSiteGeneration;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\RuntimeException;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\StaticSiteGeneration\StaticPagesGenerator;
+
+class StaticPagesGeneratorTest extends TestCase
+{
+    public function testGenerateContent()
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $response = new Response('foo-content');
+
+        $kernel->method('handle')
+            ->willReturn($response);
+
+        $generator = new StaticPagesGenerator($kernel);
+        ['content' => $content, 'format' => $format] = $generator->generate('/whatever');
+
+        $this->assertSame('foo-content', $content);
+        $this->assertNull($format);
+    }
+
+    public function testThrowOnNotOk()
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $response = new Response('foo-content', 404);
+
+        $kernel->method('handle')
+            ->willReturn($response);
+
+        $generator = new StaticPagesGenerator($kernel);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Expected URI "/whatever" to return status code 200, got 404.');
+        $generator->generate('/whatever');
+    }
+
+    public function testTerminateKernel()
+    {
+        $response = new Response('foo-content');
+
+        $kernel = $this->createMock(HttpKernel::class);
+        $kernel->expects($this->once())
+            ->method('terminate');
+
+        $kernel->method('handle')
+            ->willReturn($response);
+
+        $generator = new StaticPagesGenerator($kernel);
+        $generator->generate('/whatever');
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -21,6 +21,7 @@
         "symfony/error-handler": "^6.4|^7.0|^8.0",
         "symfony/event-dispatcher": "^7.3|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
+        "symfony/filesystem": "^7.4",
         "symfony/polyfill-ctype": "^1.8",
         "psr/log": "^1|^2|^3"
     },

--- a/src/Symfony/Component/Routing/Attribute/Route.php
+++ b/src/Symfony/Component/Routing/Attribute/Route.php
@@ -33,22 +33,23 @@ class Route
     public array $aliases = [];
 
     /**
-     * @param string|array<string,string>|null                  $path         The route path (i.e. "/user/login")
-     * @param string|null                                       $name         The route name (i.e. "app_user_login")
-     * @param array<string|\Stringable>                         $requirements Requirements for the route attributes, @see https://symfony.com/doc/current/routing.html#parameters-validation
-     * @param array<string, mixed>                              $options      Options for the route (i.e. ['prefix' => '/api'])
-     * @param array<string, mixed>                              $defaults     Default values for the route attributes and query parameters
-     * @param string|null                                       $host         The host for which this route should be active (i.e. "localhost")
-     * @param string|string[]                                   $methods      The list of HTTP methods allowed by this route
-     * @param string|string[]                                   $schemes      The list of schemes allowed by this route (i.e. "https")
-     * @param string|null                                       $condition    An expression that must evaluate to true for the route to be matched, @see https://symfony.com/doc/current/routing.html#matching-expressions
-     * @param int|null                                          $priority     The priority of the route if multiple ones are defined for the same path
-     * @param string|null                                       $locale       The locale accepted by the route
-     * @param string|null                                       $format       The format returned by the route (i.e. "json", "xml")
-     * @param bool|null                                         $utf8         Whether the route accepts UTF-8 in its parameters
-     * @param bool|null                                         $stateless    Whether the route is defined as stateless or stateful, @see https://symfony.com/doc/current/routing.html#stateless-routes
-     * @param string|string[]|null                              $env          The env(s) in which the route is defined (i.e. "dev", "test", "prod", ["dev", "test"])
-     * @param string|DeprecatedAlias|(string|DeprecatedAlias)[] $alias        The list of aliases for this route
+     * @param string|array<string,string>|null                        $path             The route path (i.e. "/user/login")
+     * @param string|null                                             $name             The route name (i.e. "app_user_login")
+     * @param array<string|\Stringable>                               $requirements     Requirements for the route attributes, @see https://symfony.com/doc/current/routing.html#parameters-validation
+     * @param array<string, mixed>                                    $options          Options for the route (i.e. ['prefix' => '/api'])
+     * @param array<string, mixed>                                    $defaults         Default values for the route attributes and query parameters
+     * @param string|null                                             $host             The host for which this route should be active (i.e. "localhost")
+     * @param string|string[]                                         $methods          The list of HTTP methods allowed by this route
+     * @param string|string[]                                         $schemes          The list of schemes allowed by this route (i.e. "https")
+     * @param string|null                                             $condition        An expression that must evaluate to true for the route to be matched, @see https://symfony.com/doc/current/routing.html#matching-expressions
+     * @param int|null                                                $priority         The priority of the route if multiple ones are defined for the same path
+     * @param string|null                                             $locale           The locale accepted by the route
+     * @param string|null                                             $format           The format returned by the route (i.e. "json", "xml")
+     * @param bool|null                                               $utf8             Whether the route accepts UTF-8 in its parameters
+     * @param bool|null                                               $stateless        Whether the route is defined as stateless or stateful, @see https://symfony.com/doc/current/routing.html#stateless-routes
+     * @param string|string[]|null                                    $env              The env(s) in which the route is defined (i.e. "dev", "test", "prod", ["dev", "test"])
+     * @param string|DeprecatedAlias|(string|DeprecatedAlias)[]       $alias            The list of aliases for this route
+     * @param bool|array{params?: string|iterable<array<mixed>>}|null $staticGeneration The static generation configuration, params : route parameters
      */
     public function __construct(
         public string|array|null $path = null,
@@ -67,6 +68,7 @@ class Route
         ?bool $stateless = null,
         string|array|null $env = null,
         string|DeprecatedAlias|array $alias = [],
+        bool|array|null $staticGeneration = null,
     ) {
         $this->path = $path;
         $this->methods = (array) $methods;
@@ -88,6 +90,10 @@ class Route
 
         if (null !== $stateless) {
             $this->defaults['_stateless'] = $stateless;
+        }
+
+        if (null !== $staticGeneration) {
+            $this->defaults['_static_generation'] = $staticGeneration;
         }
     }
 

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * Add argument `$parameters` to `RequestContext`'s constructor
  * Deprecate class aliases in the `Annotation` namespace, use attributes instead
  * Deprecate getters and setters in attribute classes in favor of public properties
+ * Add `static_generation` to `Route` defaults
+ * Add `StaticPageUrisProviderInterface` to list URIs considered as static pages
 
 7.3
 ---

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -169,4 +169,14 @@ trait RouteTrait
 
         return $this;
     }
+
+    /**
+     * @param bool|array{params?: string|iterable<array<mixed>>} $staticGeneration
+     */
+    final public function staticGeneration(bool|array $staticGeneration = true): static
+    {
+        $this->route->addDefaults(['_static_generation' => $staticGeneration]);
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -321,6 +321,15 @@ class XmlFileLoader extends FileLoader
 
             $defaults['_stateless'] = XmlUtils::phpize($stateless);
         }
+        if ($staticGeneration = $node->getAttribute('static-generation')) {
+            if (isset($defaults['_static_generation'])) {
+                $name = $node->hasAttribute('id') ? \sprintf('"%s".', $node->getAttribute('id')) : \sprintf('the "%s" tag.', $node->tagName);
+
+                throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "static-generation" attribute and the defaults key "_static_generation" for ', $path).$name);
+            }
+
+            $defaults['_static_generation'] = XmlUtils::phpize($staticGeneration);
+        }
 
         if (!$hosts) {
             $hosts = $node->hasAttribute('host') ? $node->getAttribute('host') : null;

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -34,7 +34,7 @@ class YamlFileLoader extends FileLoader
     use PrefixTrait;
 
     private const AVAILABLE_KEYS = [
-        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root', 'locale', 'format', 'utf8', 'exclude', 'stateless',
+        'resource', 'type', 'prefix', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options', 'condition', 'controller', 'name_prefix', 'trailing_slash_on_root', 'locale', 'format', 'utf8', 'exclude', 'stateless', 'static_generation',
     ];
     private YamlParser $yamlParser;
 
@@ -154,6 +154,9 @@ class YamlFileLoader extends FileLoader
         if (isset($config['stateless'])) {
             $defaults['_stateless'] = $config['stateless'];
         }
+        if (isset($config['static_generation'])) {
+            $defaults['_static_generation'] = $config['static_generation'];
+        }
 
         $routes = $this->createLocalizedRoute(new RouteCollection(), $name, $config['path']);
         $routes->addDefaults($defaults);
@@ -202,6 +205,9 @@ class YamlFileLoader extends FileLoader
         }
         if (isset($config['stateless'])) {
             $defaults['_stateless'] = $config['stateless'];
+        }
+        if (isset($config['static_generation'])) {
+            $defaults['_static_generation'] = $config['static_generation'];
         }
 
         $this->setCurrentDir(\dirname($path));
@@ -270,6 +276,9 @@ class YamlFileLoader extends FileLoader
         }
         if (isset($config['stateless']) && isset($config['defaults']['_stateless'])) {
             throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "stateless" key and the defaults key "_stateless" for "%s".', $path, $name));
+        }
+        if (isset($config['static_generation']) && isset($config['defaults']['_static_generation'])) {
+            throw new \InvalidArgumentException(\sprintf('The routing file "%s" must not specify both the "static_generation" key and the defaults key "_static_generation" for "%s".', $path, $name));
         }
     }
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -67,6 +67,7 @@
     <xsd:attribute name="format" type="xsd:string" />
     <xsd:attribute name="utf8" type="xsd:boolean" />
     <xsd:attribute name="stateless" type="xsd:boolean" />
+    <xsd:attribute name="static-generation" type="xsd:boolean" />
     <xsd:attribute name="alias" type="xsd:string" />
   </xsd:complexType>
 
@@ -92,6 +93,7 @@
     <xsd:attribute name="trailing-slash-on-root" type="xsd:boolean" />
     <xsd:attribute name="utf8" type="xsd:boolean" />
     <xsd:attribute name="stateless" type="xsd:boolean" />
+    <xsd:attribute name="static-generation" type="xsd:boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="resource">

--- a/src/Symfony/Component/Routing/StaticSiteGeneration/ParamsProviderInterface.php
+++ b/src/Symfony/Component/Routing/StaticSiteGeneration/ParamsProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\StaticSiteGeneration;
+
+/**
+ * Provide parameters for a static route.
+ *
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+interface ParamsProviderInterface
+{
+    /**
+     * @return iterable<array<string, mixed>>
+     */
+    public function provideParams(): iterable;
+}

--- a/src/Symfony/Component/Routing/StaticSiteGeneration/StaticPageUrisProvider.php
+++ b/src/Symfony/Component/Routing/StaticSiteGeneration/StaticPageUrisProvider.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\StaticSiteGeneration;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+use Symfony\Component\Routing\Exception\LogicException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+final readonly class StaticPageUrisProvider implements StaticPageUrisProviderInterface
+{
+    public function __construct(
+        private RouterInterface $router,
+        private ContainerInterface $paramsProviders,
+    ) {
+    }
+
+    /**
+     * WARNING: This method should never be used at runtime as it is SLOW.
+     *
+     * @return iterable<string>
+     *
+     * @throws LogicException           if a route noted static is not configured properly
+     * @throws InvalidArgumentException if some route parameters cannot be met
+     */
+    public function provide(): iterable
+    {
+        foreach ($this->router->getRouteCollection() as $routeName => $route) {
+            /** @var bool|array{params?: string|iterable<array<mixed>>} */
+            $config = $route->getDefaults()['_static_generation'] ?? null;
+            if (!$config) {
+                continue;
+            }
+
+            if ([] !== $route->getMethods() && !\in_array(Request::METHOD_GET, $route->getMethods(), true)) {
+                throw new LogicException(\sprintf('Expected route "%s" to accept GET method, it accepts "%s" only.', $routeName, implode(', ', $route->getMethods())));
+            }
+
+            if (false === ($route->getDefaults()['_stateless'] ?? false)) {
+                throw new LogicException(\sprintf('Expected route "%s" to be stateless.', $routeName));
+            }
+
+            $compiledRoute = $route->compile();
+
+            // $config "true" means no params to match the path variables
+            if ([] === $compiledRoute->getPathVariables() || true === $config) {
+                yield $this->router->generate($routeName);
+
+                continue;
+            }
+
+            if (!isset($config['params'])) {
+                throw new LogicException(\sprintf('Missing "params" configuration for route "%s".', $routeName));
+            }
+
+            $paramsList = $this->getParamsList($config['params']);
+            foreach ($compiledRoute->getPathVariables() as $pathVariable) {
+                foreach ($paramsList as $params) {
+                    yield $this->router->generate($routeName, $params);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string|list<array<string, mixed>> $params
+     *
+     * @return iterable<array<string, mixed>>
+     *
+     * @throws InvalidArgumentException
+     */
+    private function getParamsList(array|string $params): iterable
+    {
+        if (\is_string($params)) {
+            $serviceId = $params;
+            if (!$this->paramsProviders->has($serviceId)) {
+                throw new InvalidArgumentException(\sprintf('You have requested a non-existent params provider service "%s". Did you implement "%s"?', $serviceId, ParamsProviderInterface::class));
+            }
+
+            $paramsProvider = $this->paramsProviders->get($serviceId);
+            if (!$paramsProvider instanceof ParamsProviderInterface) {
+                throw new InvalidArgumentException(\sprintf('The "%s" params provider service does not implement "%s".', $serviceId, ParamsProviderInterface::class));
+            }
+
+            return $paramsProvider->provideParams();
+        }
+
+        return $params;
+    }
+}

--- a/src/Symfony/Component/Routing/StaticSiteGeneration/StaticPageUrisProviderInterface.php
+++ b/src/Symfony/Component/Routing/StaticSiteGeneration/StaticPageUrisProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\StaticSiteGeneration;
+
+/**
+ * List URIs considered as static pages.
+ *
+ * @author Thomas Bibaut <bibaut.t@gmail.com>
+ */
+interface StaticPageUrisProviderInterface
+{
+    /**
+     * @return iterable<string>
+     */
+    public function provide(): iterable;
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/defaults.xml
@@ -4,5 +4,5 @@
         xsi:schemaLocation="http://symfony.com/schema/routing
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="defaults" path="/defaults" locale="en" format="html" stateless="true" />
+    <route id="defaults" path="/defaults" locale="en" format="html" stateless="true" static-generation="true"/>
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/defaults.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/defaults.yml
@@ -3,3 +3,4 @@ defaults:
   locale: en
   format: html
   stateless: true
+  static_generation: true

--- a/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.xml
@@ -7,5 +7,6 @@
     <import resource="imported-with-defaults.xml" prefix="/defaults"
             locale="g_locale"
             format="g_format"
-            stateless="true" />
+            stateless="true"
+            static-generation="true" />
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/importer-with-defaults.yml
@@ -4,3 +4,4 @@ defaults:
   locale: g_locale
   format: g_format
   stateless: true
+  static_generation: true

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
@@ -9,6 +9,9 @@
         <default key="_stateless">
             <bool>true</bool>
         </default>
+        <default key="_static_generation">
+            <bool>true</bool>
+        </default>
         <requirement key="locale">\w+</requirement>
         <option key="compiler_class">RouteCompiler</option>
         <condition>context.getMethod() == "GET"</condition>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
@@ -1,6 +1,6 @@
 blog_show:
     path:         /blog/{slug}
-    defaults:     { _controller: "MyBundle:Blog:show", _stateless: true }
+    defaults:     { _controller: "MyBundle:Blog:show", _stateless: true, _static_generation: true }
     host:         "{locale}.example.com"
     requirements: { 'locale': '\w+' }
     methods:      ['GET','POST','put','OpTiOnS']

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -53,6 +53,7 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(['https'], $route->getSchemes());
         $this->assertEquals('context.getMethod() == "GET"', $route->getCondition());
         $this->assertTrue($route->getDefault('_stateless'));
+        $this->assertTrue($route->getDefault('_static_generation'));
     }
 
     public function testLoadWithNamespacePrefix()
@@ -105,6 +106,7 @@ class XmlFileLoaderTest extends TestCase
         $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
         $this->assertSame('html', $defaultsRoute->getDefault('_format'));
         $this->assertTrue($defaultsRoute->getDefault('_stateless'));
+        $this->assertTrue($defaultsRoute->getDefault('_static_generation'));
     }
 
     public function testLoadingImportedRoutesWithDefaults()
@@ -119,10 +121,12 @@ class XmlFileLoaderTest extends TestCase
         $localeRoute->setDefault('_locale', 'g_locale');
         $localeRoute->setDefault('_format', 'g_format');
         $localeRoute->setDefault('_stateless', true);
+        $localeRoute->setDefault('_static_generation', true);
         $expectedRoutes->add('two', $formatRoute = new Route('/defaults/two'));
         $formatRoute->setDefault('_locale', 'g_locale');
         $formatRoute->setDefault('_format', 'g_format');
         $formatRoute->setDefault('_stateless', true);
+        $formatRoute->setDefault('_static_generation', true);
         $formatRoute->setDefault('specific', 'imported');
 
         $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/imported-with-defaults.xml'));

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -99,6 +99,7 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(['https'], $route->getSchemes());
         $this->assertEquals('context.getMethod() == "GET"', $route->getCondition());
         $this->assertTrue($route->getDefault('_stateless'));
+        $this->assertTrue($route->getDefault('_static_generation'));
     }
 
     public function testLoadWithResource()
@@ -244,6 +245,7 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame('en', $defaultsRoute->getDefault('_locale'));
         $this->assertSame('html', $defaultsRoute->getDefault('_format'));
         $this->assertTrue($defaultsRoute->getDefault('_stateless'));
+        $this->assertTrue($defaultsRoute->getDefault('_static_generation'));
     }
 
     public function testLoadingImportedRoutesWithDefaults()
@@ -258,10 +260,12 @@ class YamlFileLoaderTest extends TestCase
         $localeRoute->setDefault('_locale', 'g_locale');
         $localeRoute->setDefault('_format', 'g_format');
         $localeRoute->setDefault('_stateless', true);
+        $localeRoute->setDefault('_static_generation', true);
         $expectedRoutes->add('two', $formatRoute = new Route('/defaults/two'));
         $formatRoute->setDefault('_locale', 'g_locale');
         $formatRoute->setDefault('_format', 'g_format');
         $formatRoute->setDefault('_stateless', true);
+        $formatRoute->setDefault('_static_generation', true);
         $formatRoute->setDefault('specific', 'imported');
 
         $expectedRoutes->addResource(new FileResource(__DIR__.'/../Fixtures/imported-with-defaults.yml'));

--- a/src/Symfony/Component/Routing/Tests/StaticSiteGeneration/StaticPageUrisProviderTest.php
+++ b/src/Symfony/Component/Routing/Tests/StaticSiteGeneration/StaticPageUrisProviderTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\StaticSiteGeneration;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+use Symfony\Component\Routing\Exception\LogicException;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\StaticSiteGeneration\ParamsProviderInterface;
+use Symfony\Component\Routing\StaticSiteGeneration\StaticPageUrisProvider;
+
+class StaticPageUrisProviderTest extends TestCase
+{
+    public function testProvideUris()
+    {
+        $routes = new RouteCollection();
+        $routes->add('no_config', new Route('/no_config'));
+        $routes->add('true_config', new Route('/true_config', ['_stateless' => true, '_static_generation' => true]));
+        $routes->add('empty_params', new Route('/empty_params', ['_stateless' => true, '_static_generation' => ['params' => []]]));
+        $routes->add('array_params', new Route('/array_params/{param}', ['_stateless' => true, '_static_generation' => ['params' => [['param' => 'foo']]]]));
+        $routes->add('extra_param', new Route('/extra_param', ['_stateless' => true, '_static_generation' => ['_stateless' => true, 'params' => [['param' => 'foo']]]]));
+        $routes->add('service_param', new Route('/service_param/{param}', ['_stateless' => true, '_static_generation' => ['params' => 'fooParamProvider']]));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramProvider = $this->createStub(ParamsProviderInterface::class);
+        $paramProvider->method('provideParams')
+            ->willReturn([['param' => 'foo']]);
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+        $paramsProviders->method('get')
+            ->with('fooParamProvider')
+            ->willReturn($paramProvider);
+
+        $paramsProviders->method('has')
+            ->with('fooParamProvider')
+            ->willReturn(true);
+
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+
+        $this->assertSame([
+            '/true_config',
+            '/empty_params',
+            '/array_params/foo',
+            '/extra_param',
+            '/service_param/foo',
+        ], iterator_to_array($provider->provide()));
+    }
+
+    public function testThrowsOnRouteDoesNotAcceptGet()
+    {
+        $routes = new RouteCollection();
+        $routes->add('post_route', new Route(path: '/post_route', defaults: ['_static_generation' => true], methods: ['POST']));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Expected route "post_route" to accept GET method, it accepts "POST" only.');
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+        iterator_to_array($provider->provide());
+    }
+
+    public function testThrowsOnStatelessRoute()
+    {
+        $routes = new RouteCollection();
+        $routes->add('statefull_route', new Route('/statefull_route', ['_static_generation' => true, '_stateless' => false]));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Expected route "statefull_route" to be stateless');
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+        iterator_to_array($provider->provide());
+    }
+
+    public function testThrowsOnMissingParamsConfig()
+    {
+        $routes = new RouteCollection();
+        $routes->add('missing_params', new Route('/missing_params/{param}', ['_stateless' => true, '_static_generation' => ['foo' => 'bar']]));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Missing "params" configuration for route "missing_params"');
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+        iterator_to_array($provider->provide());
+    }
+
+    public function testThrowsOnServiceNonExistent()
+    {
+        $routes = new RouteCollection();
+        $routes->add('undefined_service', new Route('/undefined_service/{param}', ['_stateless' => true, '_static_generation' => ['params' => 'undefinedService']]));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('You have requested a non-existent params provider service "undefinedService". Did you implement "Symfony\Component\Routing\StaticSiteGeneration\ParamsProviderInterface"?');
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+        iterator_to_array($provider->provide());
+    }
+
+    public function testThrowsOnInvalidParamProvider()
+    {
+        $routes = new RouteCollection();
+        $routes->add('invalid_service', new Route('/invalid_service/{param}', ['_stateless' => true, '_static_generation' => ['params' => 'invalidService']]));
+
+        $loader = $this->createStub(LoaderInterface::class);
+        $loader->method('load')->willReturn($routes);
+        $router = new Router($loader, 'useless');
+
+        $paramProvider = $this->createStub(\stdClass::class);
+
+        $paramsProviders = $this->createMock(ContainerInterface::class);
+        $paramsProviders->method('get')
+            ->with('invalidService')
+            ->willReturn($paramProvider);
+
+        $paramsProviders->method('has')
+            ->with('invalidService')
+            ->willReturn(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "invalidService" params provider service does not implement "Symfony\Component\Routing\StaticSiteGeneration\ParamsProviderInterface".');
+        $provider = new StaticPageUrisProvider($router, $paramsProviders);
+        iterator_to_array($provider->provide());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT


This PR allows a route to be defined as "static generated".

A static generated route is dumped on a storage thanks to a Symfony command: `static-site-generation:generate`.
With a simple NGINX / Caddy configuration, the generated files could be served directly.
Example with Caddy :
```
{$SERVER_NAME:localhost} {
	root * /app/public
	encode zstd gzip

	{$CADDY_SERVER_EXTRA_DIRECTIVES}

	try_files {path} /static-pages{path}.html
	try_files {path} /static-pages{path}

	php_server
}
```

A good use case for this feature is a blog, where pages almost never change.
In that case, if the route is configured as static generated, Symfony won't even load, as the server serves the generate page directly (which implies a huge performance boost).

Similar implementations can be found in [Tempest](https://tempestphp.com/1.x/features/static-pages), [Astro](https://docs.astro.build/en/guides/routing/#static-routes), and many other frameworks.


Here is an overview of the feature architecture:
![ssg](https://github.com/user-attachments/assets/ae510900-96cb-47da-9ba3-a87dfe6e959c)

`StaticPageUrisProvider` lists all Route marked as static, those can be defined as follows :
```php
#[Route(name: 'app_sitemap', path: 'sitemap.xml', methods: ['GET'], format: 'xml', staticGeneration: true)]
public function __invoke(): Response
// ...
```

`staticGeneration` configuration can be :

-  a boolean
```php
#[Route(name: 'home', path: '/', staticGeneration: true)]
```
-  a static array
```php
#[Route(name: 'restaurant_detail', path: '/restaurant/{city}', staticGeneration: [['city' => 'lyon'], ['city' => 'hanoi']])]
```
-  a service ID (tagged with `routing.static_site.params_provider`)
```php
#[Route(name: 'product_detail', path: '/product/{slug}', staticGeneration: ProductSlugProvider::class)]
```

There are some extension points :
- `StaticPageUrisProviderInterface` to provide static page by another mean than `symfony/routing`. A third party CMS system for example.
- `ParamsProviderInterface` to resolve params of dynamic routes. For example, with a route `/blog/{slug}`. We can create a param providers to list all slugs from a database, or all Markdown files in a directory.
- `StaticPageDumperInterface` to dump the pages content on another storage. Can be useful if we need to dump it to an S3 storage, to GitHub pages, ...




 



